### PR TITLE
Replace react.proptypes by package prop-types

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -3,7 +3,9 @@
  */
 'use strict';
 
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+
 import {
     View, Text, Image, TouchableHighlight
 } from 'react-native';

--- a/package.json
+++ b/package.json
@@ -3,8 +3,7 @@
   "version": "2.0.0",
   "description": "",
   "main": "lib/index.js",
-  "scripts": {
-  },
+  "scripts": {},
   "files": [
     "lib"
   ],
@@ -24,5 +23,8 @@
   "_id": "react-native-keyboard@1.0.0",
   "_shasum": "902d4878c1c66a2a8ef8075d674279ececd027a5",
   "_from": "git+https://github.com/beefe/react-native-keyboard.git",
-  "_resolved": "git+https://github.com/beefe/react-native-keyboard.git#e79e1eace4d0dab225ea07e7c3d02a2b7fb80b07"
+  "_resolved": "git+https://github.com/beefe/react-native-keyboard.git#e79e1eace4d0dab225ea07e7c3d02a2b7fb80b07",
+  "peerDependencies": {
+    "prop-types": "^15.6.1"
+  }
 }


### PR DESCRIPTION
Following issue #6 I've noticed you use `PropTypes` from React@15 that are deprecated and [should be replaced by prop-types](https://reactjs.org/docs/typechecking-with-proptypes.html).